### PR TITLE
Refresh stage 2

### DIFF
--- a/src/main/java/dk/kb/image/api/v1/impl/ServiceApiServiceImpl.java
+++ b/src/main/java/dk/kb/image/api/v1/impl/ServiceApiServiceImpl.java
@@ -54,7 +54,7 @@ public class ServiceApiServiceImpl extends ImplBase implements ServiceApi {
                     .version(BuildInfoManager.getVersion())
                     .build(BuildInfoManager.getBuildTime())
                     .java(System.getProperty("java.version"))
-                    .heap(Runtime.getRuntime().maxMemory() / 1000000L)
+                    .heap(Runtime.getRuntime().maxMemory() / 1048576)
                     .server(host)
                     .health("ok");
         } catch (Exception e) {

--- a/src/main/java/dk/kb/image/webservice/ContextListener.java
+++ b/src/main/java/dk/kb/image/webservice/ContextListener.java
@@ -1,6 +1,8 @@
 package dk.kb.image.webservice;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
 
 import javax.naming.InitialContext;
@@ -32,7 +34,12 @@ public class ContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         try {
-            log.info("Initializing service {} {} build {} using Java {} with Xmx={}MB on machine {}",
+            RuntimeMXBean mxBean = ManagementFactory.getRuntimeMXBean();
+            if (mxBean.getInputArguments().stream().noneMatch(arg -> arg.startsWith("-Xmx"))) {
+                log.warn("Xmx is not specified. In stage or production this is almost always an error");
+            }
+
+            log.info("Initializing service {} {} build {} using Java {} with max heap {}MB on machine {}",
                      BuildInfoManager.getName(), BuildInfoManager.getVersion(), BuildInfoManager.getBuildTime(),
                      System.getProperty("java.version"), Runtime.getRuntime().maxMemory()/1048576,
                      InetAddress.getLocalHost().getHostName());


### PR DESCRIPTION
Second part of general refresh of ds-services:

* Warn on missing `Xmx` on startup (look for "Xmx is not specified...")